### PR TITLE
Add `doc/*.md` files describing accepted file formats

### DIFF
--- a/crates/lifelib/src/formats/plaintext.rs
+++ b/crates/lifelib/src/formats/plaintext.rs
@@ -7,54 +7,14 @@ use std::str::FromStr;
 use thiserror::Error;
 
 /// A pattern represented in the [plaintext file
-/// format](https://conwaylife.com/wiki/Plaintext)
+/// format](https://conwaylife.com/wiki/Plaintext).  The exact format accepted
+/// by `lifelib` is described in [`doc/plaintext.md`][1].
+///
+/// [1]: https://github.com/jwodder/life/blob/master/doc/plaintext.md
 ///
 /// A `Plaintext` instance can be constructed from a plaintext string via
 /// [`FromStr`] and converted to the plaintext format via
 /// [`Display`][fmt::Display] (which includes a trailing newline).
-///
-/// # Format
-///
-/// The plaintext file format encodes a Game of Life pattern as follows:
-///
-/// - The first line must start with `"!Name:"`.  The rest of the line is a
-///   name for the pattern.
-///
-///   - This implementation requires that the colon be followed by one or more
-///     space (U+0020) characters, all of which are discarded when parsing.
-///
-///   - This implementation accepts empty names.
-///
-/// - After the first line, there may be any number of comment lines, each of
-///   which begins with an exclamation point (`!`), which is discarded when
-///   parsing.
-///
-/// - The remaining lines define the pattern itself via an ASCII drawing.  Each
-///   row of the pattern is represented as a line in which `.` denotes a dead
-///   cell and `O` denotes a live cell.
-///
-///   - Drawings in which not all lines are of the same length are accepted but
-///     discouraged.
-///
-///   - Blank lines in a drawing (denoting rows composed entirely of dead
-///     cells) are accepted but discouraged.
-///
-///   - This implementation does not accept any characters other than `.`, `O`,
-///     and newlines in a drawing.  In particular, comments may not occur in
-///     the middle of a drawing.
-///
-/// - This implementation recognizes only LF, CR, and CR LF as newline
-///   sequences.
-///
-/// A plaintext encoding of the [glider](https://conwaylife.com/wiki/Glider):
-///
-/// ```text
-/// !Name: Glider
-/// !Very famous.
-/// .O.
-/// ..O
-/// OOO
-/// ```
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Plaintext {
     /// Name of the pattern

--- a/crates/lifelib/src/formats/rle.rs
+++ b/crates/lifelib/src/formats/rle.rs
@@ -10,7 +10,10 @@ use std::str::FromStr;
 use thiserror::Error;
 
 /// A pattern represented in the [run length encoded file
-/// format](https://conwaylife.com/wiki/Run_Length_Encoded)
+/// format](https://conwaylife.com/wiki/Run_Length_Encoded).  The exact format
+/// accepted by `lifelib` is described in [`doc/rle.md`][1].
+///
+/// [1]: https://github.com/jwodder/life/blob/master/doc/rle.md
 ///
 /// An `Rle` instance can be constructed from an RLE string via [`FromStr`] and
 /// converted to the RLE format via [`Display`][fmt::Display] (which includes a
@@ -90,32 +93,6 @@ impl FromStr for Rle {
     /// # Errors
     ///
     /// See [`RleError`] for the various error conditions.
-    ///
-    /// # Implementation-Specific Parsing Details
-    ///
-    /// This implementation makes the following decisions about how to parse
-    /// the RLE format:
-    ///
-    /// - A `#` line must consist of, in order, a `#`, any single non-newline
-    ///   character, one or more space (U+0020) characters (discarded), and
-    ///   freeform text.
-    ///
-    /// - Blank lines (containing no characters other than Unicode whitespace)
-    ///   are permitted at any point.
-    ///
-    /// - Tokens in the header line may be surrounded by zero or more Unicode
-    ///   whitespace characters other than newline sequences.
-    ///
-    /// - The header line may contain an optional "rule" field, but it must
-    ///   equal `B3/S23` or `23/3`.
-    ///
-    /// - Tokens in the pattern data may be separated by zero or more Unicode
-    ///   whitespace characters.
-    ///
-    /// - Specifications for cells outside the width & height given in the
-    ///   header are accepted but ignored.
-    ///
-    /// - Run counts of zero are accepted but, obviously, have no effect.
     fn from_str(s: &str) -> Result<Rle, RleError> {
         let mut cparser = CommentParser(s);
         let mut comments = Vec::new();

--- a/doc/plaintext.md
+++ b/doc/plaintext.md
@@ -1,0 +1,64 @@
+The following is an exact specification of the [plaintext file format][] for
+[Conway's Game of Life][] patterns as recognized by `lifelib`.
+
+[plaintext file format]: https://conwaylife.com/wiki/Plaintext
+[Conway's Game of Life]: https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life
+
+- A plaintext document must be encoded in UTF-8 and may not begin with a
+  byte-order marker.
+
+- Lines in a plaintext document are terminated by LF, CR, and/or CR LF.  The
+  line terminator may be omitted from the last line of a plaintext document,
+  but this is discouraged.
+
+- The following "exotic" line endings may not occur anywhere in a plaintext
+  document:
+    - U+000B LINE TABULATION (a.k.a. "vertical tab," "VTAB," or "VT")
+    - U+000C FORM FEED (FF)
+    - U+0085 NEXT LINE (NEL)
+    - U+2028 LINE SEPARATOR
+    - U+2029 PARAGRAPH SEPARATOR
+
+- A plaintext document consists of zero or more *comment lines* followed by a
+  *pattern drawing*.
+
+- A *comment line* is a line whose first character is `!`.  The remainder of
+  the line is a human-readable comment.
+
+- If the first comment line in a plaintext document begins with `!Name:`
+  followed by one or more space (U+0020) characters, then the remainder of the
+  line (not including the line terminator) specifies the name of the pattern.
+  Names may be empty.
+
+- A *pattern drawing* is an ASCII drawing of the Game of Life pattern described
+  by the document.  The drawing consists of zero or more lines that specify
+  each row of the pattern from top to bottom.  Each line consists of zero or
+  more `.` and/or `O` characters that specify the cells of the row from left to
+  right, with `.` denoting a dead cell and `O` denoting a live cell.
+
+- It is permitted but discouraged for the lines of a pattern drawing to be of
+  unequal length.  Such drawings are parsed as though the shorter lines were
+  padded with dead cells on the end/right to match the length of the longest
+  line in the drawing.
+
+    - Blank lines in a pattern drawing (denoting rows composed entirely of dead
+      cells) are accepted but discouraged.
+
+- Empty pattern drawings are accepted.
+
+- A pattern drawing may not contain any characters other than `.`, `O`, and
+  line terminators.  In particular, comment lines are not allowed in the middle
+  of a pattern drawing.
+
+Example
+-------
+
+A plaintext document representing the [glider](https://conwaylife.com/wiki/Glider):
+
+```text
+!Name: Glider
+!Very famous.
+.O.
+..O
+OOO
+```

--- a/doc/rle.md
+++ b/doc/rle.md
@@ -1,0 +1,151 @@
+The following is an exact specification of the [run length encoded (RLE) file
+format][RLE] for [Conway's Game of Life][] patterns as recognized by `lifelib`.
+
+- An RLE document must be encoded in UTF-8 and may not begin with a byte-order
+  marker.
+
+- Lines in an RLE document are terminated by LF, CR, and/or CR LF.  The line
+  terminator may be omitted from the last line of an RLE document, but this is
+  discouraged.
+
+- The following "exotic" line endings may not occur anywhere in an RLE
+  document:
+    - U+000B LINE TABULATION (a.k.a. "vertical tab," "VTAB," or "VT")
+    - U+000C FORM FEED (FF)
+    - U+0085 NEXT LINE (NEL)
+    - U+2028 LINE SEPARATOR
+    - U+2029 PARAGRAPH SEPARATOR
+
+- The following is a grammar for RLE documents defined using Augmented BNF as
+  described in [RFC 5234][] and updated by [RFC 7405][]:
+
+    ```text
+    rle-document  =  *(hash-line / blank-line) header *blank-line pattern
+
+    hash-line     =  "#" LETTER 1*SP text NL
+                        ; a "# line"
+
+    text          =  *char-no-nl
+
+    blank-line    =  *WSP NL
+                        ; line containing only whitespace
+
+    header        =  *WSP width *WSP "," *WSP height *WSP ["," *WSP rule *WSP] NL
+                        ; header line
+
+    width         =  %s"x" *WSP "=" *WSP integer
+                        ; width of the pattern
+
+    height        =  %s"y" *WSP "=" *WSP integer
+                        ; height of the pattern
+
+    rule          =  %s"rule" *WSP = *WSP ( %s"B3/S23" / "23/3" )
+                        ; cellular automaton rule for the pattern
+                        ; Only the standard Game of Life is allowed.
+
+    pattern       =  *(*LWSP run) *LWSP "!"
+
+    run           =  [integer] ( %s"b" / %s"o" / "$" )
+
+    char-no-nl    =  <any single Unicode character other than U+000A, U+000B,
+                      U+000C, U+000D, U+0085, U+2028, and U+2029>
+
+    integer       =  1*DIGIT
+                        ; a nonnegative decimal integer
+                        ; The maximum permitted value for an integer production
+                        ;     is the platform's `usize::MAX` value.
+
+    LETTER        =  %x41-5A / %x61-7A
+                        ; A-Z / a-z
+
+    DIGIT         =  %x30-39
+                        ; 0-9
+
+    WSP           =  SP / HTAB
+                        ; ASCII horizontal white space
+
+    LWSP          =  WSP / NL
+
+    NL            =  LF / CR LF / CR
+                        ; line terminator
+
+    HTAB          =  %x09
+                        ; horizontal tab
+
+    LF            =  %x0A
+                        ; linefeed character
+
+    CR            =  %x0D
+                        ; carriage return
+
+    SP            =  %x20
+                        ; space character
+    ```
+
+- The `#` lines in an RLE document (defined by the `<hash-line>` rule in the
+  ABNF) contain metadata about the pattern.  The `<LETTER>` element of a `#`
+  line specifies the type of metadata described by the line, and the `<text>`
+  element is the value of the metadata.  `lifelib` only assigns meanings to the
+  following `<LETTER>` values:
+    - `N` — The `<text>` element specifies the name of the pattern.  If an RLE
+      document contains multiple `#` lines of type `N`, `lifelib` only honors
+      the first one.
+    - `C` — The `<text>` element is a comment.
+    - `c` — Same as `C`, but not recommended.
+
+- The header line in an RLE document (defined by the `<header>` rule in the
+  ABNF) specifies the width and height of the pattern described by the
+  document.  The width is the value of the `<integer>` element within the
+  `<width>` element, and the height is the value of the `<integer>` element
+  within the `<height>` element.
+
+- The header line may contain an optional cellular automaton rule, but the
+  value must be the [rulestring][] for the standard version of Conway's Game of
+  Life, i.e., `B3/S23` or `23/3`.
+
+- The `<pattern>` element of an RLE document describes a Conway's Game of Life
+  pattern.  It consists of zero or more `<run>` items, each of which is a pair
+  of an optional integer (the *run count*, defaulting to 1 if omitted) and a
+  *tag*.  The possible tags are `b` (denoting a dead cell), `o` (denoting a
+  live cell), and `$` (denoting the end of a row).
+
+  - The `<run>` items specify the cells of the pattern from top to bottom and
+    left to right.  A single item with a `b` or `o` tag denotes a run of
+    consecutive cells in the same row that are all dead or alive, respectively,
+    with the number of cells being equal to the item's run count.  An item with
+    a `$` tag denotes the end of a row.
+
+  - Dead cells at the end of a row do not need to be encoded, and so one or
+    more rows of all-dead cells can be encoded as an item with a `$` tag and a
+    run count equal to the number of all-dead rows.  (If the all-dead rows are
+    preceded by another row, the preceding `$` item may be merged with the `$`
+    item for the all-dead rows, transforming, e.g., `$2$` to `3$`.)
+
+  - The end of the last row of the pattern does not need to be encoded.
+
+  - Run counts of zero are accepted but do not add anything to the resulting
+    pattern.
+
+  - If the `<run>` items specify any cells outside the dimensions given in the
+    header line, those cells are ignored.
+
+- The final `<run>` item in a `<pattern>` is followed by a `!`.  Any text in
+  the document after this terminating `!` is ignored.
+
+[RLE]: https://conwaylife.com/wiki/Run_Length_Encoded
+[Conway's Game of Life]: https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life
+[rulestring]: https://conwaylife.com/wiki/Rulestring
+[RFC 5234]: https://www.rfc-editor.org/info/rfc5234
+[RFC 7405]: https://www.rfc-editor.org/info/rfc7405
+
+Example
+-------
+
+An RLE document representing the [glider](https://conwaylife.com/wiki/Glider):
+
+```text
+#N Glider
+#C Very famous.
+x = 3, y = 3
+bo$2bo$3o!
+```


### PR DESCRIPTION
Closes #87.

Prerequisites:

- [x] #74
- [x] #80
- [x] #81
- [x] #90
- [x] #91
- [x] #92